### PR TITLE
feat: fetch and display real resumes on Home page

### DIFF
--- a/app/components/ResumeCard.tsx
+++ b/app/components/ResumeCard.tsx
@@ -1,32 +1,62 @@
-import { Link } from "react-router"
-import ScoreCircle from "./ScoreCircle"
+import { Link } from "react-router";
+import { useEffect, useState } from "react";
+import { usePuterStore } from "~/lib/puter";
+import ScoreCircle from "./ScoreCircle";
 
-const ResumeCard = ({ resume: { id, companyName, jobTitle, feedback, imagePath } }: { resume: Resume }) => {
-
-
-  return (
-    <Link to={`/resume/${id}`} className="resume-card animate-in fade-in duration-1000">
-      <div className="resume-card-header">
-        <div className="flex flex-col gap-2">
-          {companyName && <h2 className="!text-black font-bold break-words">{companyName}</h2>}
-          {jobTitle && <h3 className="text-lg break-words text-gray-500">{jobTitle}</h3>}
-          {!companyName && !jobTitle && <h2 className="!text-black font-bold">Resume</h2>}
-        </div>
-        <div className="flex-shrink-0">
-          <ScoreCircle score={feedback.overallScore} />
-        </div>
-      </div>
-      <div className="gradient-border animate-in fade-in duration-1000">
-        <div className="w-full h-full">
-          <img
-            src={imagePath}
-            alt="resume"
-            className="w-full h-[350px] max-sm:h-[200px] object-cover object-top"
-          />
-        </div>
-      </div>
-    </Link>
-  )
+interface ResumeCardProps {
+  resume: Resume;
 }
 
-export default ResumeCard
+const ResumeCard = ({ resume }: ResumeCardProps) => {
+  const { fs } = usePuterStore();
+  const { id, companyName, jobTitle, feedback, imagePath } = resume;
+
+  const [resumeUrl, setResumeUrl] = useState("");
+
+  // Load resume image from Puter FS
+  useEffect(() => {
+    const loadImage = async () => {
+      try {
+        const blob = await fs.read(imagePath);
+        if (!blob) return;
+        setResumeUrl(URL.createObjectURL(blob));
+      } catch (err) {
+        console.error("Failed to load resume image:", err);
+      }
+    };
+    loadImage();
+  }, [imagePath, fs]);
+
+  return (
+    <Link to={`/feedback/${id}`} className="resume-card animate-in fade-in duration-1000">
+      <div className="resume-card-header flex justify-between items-start gap-4">
+        <div className="flex flex-col gap-2">
+          {companyName || jobTitle ? (
+            <>
+              {companyName && <h2 className="!text-black font-bold break-words">{companyName}</h2>}
+              {jobTitle && <h3 className="text-lg text-gray-500 break-words">{jobTitle}</h3>}
+            </>
+          ) : (
+            <h2 className="!text-black font-bold">Resume</h2>
+          )}
+        </div>
+
+        <div className="flex-shrink-0">
+          <ScoreCircle score={feedback?.overallScore || 0} />
+        </div>
+      </div>
+
+      {resumeUrl && (
+        <div className="gradient-border animate-in fade-in duration-1000 mt-2">
+          <img
+            src={resumeUrl}
+            alt="resume preview"
+            className="w-full h-[350px] max-sm:h-[200px] object-cover object-top rounded-xl"
+          />
+        </div>
+      )}
+    </Link>
+  );
+};
+
+export default ResumeCard;


### PR DESCRIPTION
# Pull Request: Fetch and Display Real Resumes

## Overview
This PR adds functionality to fetch real resumes from the Puter KV store and display them on the Home page. Each resume is rendered using the `ResumeCard` component, showing its preview image, company name, job title, and AI-generated feedback score.

## Changes
- **Home page (`app/routes/home.tsx`)**
  - Fetch resumes from `PuterStore.kv`.
  - Parse and store resume data in component state.
  - Display a loading indicator while resumes are being fetched.
  - Show a friendly message if no resumes are found.
  - Render a list of `ResumeCard` components for available resumes.
- **ResumeCard component (`app/components/ResumeCard.tsx`)**
  - Load resume preview images from Puter FS.
  - Display company name, job title, and overall feedback score.
  - Apply consistent fade-in animation and gradient border.

## Testing
- Verified resumes are fetched and displayed correctly.
- Handles empty KV store gracefully.
- Resume images load correctly from Puter FS.
- Clickable resume cards navigate to individual resume pages.

## Next Steps / TODO
- Add pagination or lazy loading if the number of resumes grows large.
- Enhance styling and responsiveness for mobile devices.
